### PR TITLE
Add environment variabes that are always injected by slurm client programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,3 +228,5 @@ This program is free software: you can redistribute it and/or modify it under th
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License along with this program. If not, see [http://www.gnu.org/licenses/](http://www.gnu.org/licenses/).
+
+Some portions of this program are copied or derived from Slurm, which is licensed under the GNU General Public License Version 2. For details, including the list of Slurm copyright holders,  see <[https://slurm.schedmd.com/](https://slurm.schedmd.com/)>.

--- a/slurm_drmaa/job.c
+++ b/slurm_drmaa/job.c
@@ -1,6 +1,10 @@
 /*
  * PSNC DRMAA for SLURM
- * Copyright (C) 2011 Poznan Supercomputing and Networking Center
+ * Copyright (C) 2011-2015 Poznan Supercomputing and Networking Center
+ * Copyright (C) 2014-2019 The Pennsylvania State University
+ * Portions Copyright (C) 2006-2007 The Regents of the University of California.
+ * Portions Copyright (C) 2008-2010 Lawrence Livermore National Security.
+ * Portions Copyright (C) 2010-2017 SchedMD LLC.
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/test/functional-basic.bats
+++ b/test/functional-basic.bats
@@ -26,3 +26,33 @@ load helper_slurm
     [ "$status" -eq 0 ]
     [ "$output" = "OK" ]
 }
+
+@test "ensure that submit umask is passed" {
+    slurm_available || skip "Slurm unreachable"
+    umask 027
+    drmaa_run umask
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 27 ]
+    umask 022
+    drmaa_run umask
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 22 ]
+}
+
+@test "ensure that submit host and dir variables are passed" {
+    slurm_available || skip "Slurm unreachable"
+    drmaa_run 'echo "${SLURM_SUBMIT_HOST}:${SLURM_SUBMIT_DIR}"'
+    [ "$status" -eq 0 ]
+    [ "$output" = "$(hostname):$(pwd)" ]
+}
+
+@test "ensure that process priority is passed" {
+    slurm_available || skip "Slurm unreachable"
+    drmaa_run nice
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 0 ]
+    renice -n 5 $$ >/dev/null
+    drmaa_run 'echo "$SLURM_PRIO_PROCESS"'
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 5 ]
+}


### PR DESCRIPTION
`sbatch` and `srun` always attempts to ensure that certain vars are set in the job description. These are:

- `$SLURM_PRIO_PROCESS`
- `$SLURM_SUBMIT_HOST`
- `$SLURM_SUBMIT_DIR`
- `$SLURM_PRIO_PROCESS`

slurm-drmaa was not previously doing this, and it's implemented in the Slurm client programs, not in the API, so those functions have been incorporated.

Fixes #18, supercedes #19.