### PR TITLE
Remove slurmdb from libs to link against for newer Slurm versions (>18)

### DIFF
--- a/m4/ax_slurm.m4
+++ b/m4/ax_slurm.m4
@@ -71,17 +71,18 @@ if test x$with_slurm_lib == x; then
 fi
 AC_MSG_RESULT([$with_slurm_lib$ax_slurm_msg])
 
-
-SLURM_LIBS="-lslurmdb -lslurm "
+SLURM_LIBS="-lslurm "
 SLURM_LDFLAGS="-L${with_slurm_lib}"
 
 
 CPPFLAGS_save="$CPPFLAGS"
 LDFLAGS_save="$LDFLAGS"
 LIBS_save="$LIBS"
+LD_LIBRARY_PATH_save="$LD_LIBRARY_PATH"
 CPPFLAGS="$CPPFLAGS $SLURM_INCLUDES"
 LDFLAGS="$LDFLAGS $SLURM_LDFLAGS"
 LIBS="$LIBS $SLURM_LIBS"
+LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${with_slurm_lib}"
 
 ax_slurm_ok="no"
 
@@ -101,6 +102,7 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[ #include "slurm/slurm.h" ]],
 CPPFLAGS="$CPPFLAGS_save"
 LDFLAGS="$LDFLAGS_save"
 LIBS="$LIBS_save"
+LD_LIBRARY_PATH="$LD_LIBRARY_PATH_save"
 AC_MSG_RESULT([$ax_slurm_ok])
 
 if test x"$ax_slurm_ok" = xyes; then

--- a/m4/ax_slurm.m4
+++ b/m4/ax_slurm.m4
@@ -71,18 +71,23 @@ if test x$with_slurm_lib == x; then
 fi
 AC_MSG_RESULT([$with_slurm_lib$ax_slurm_msg])
 
-SLURM_LIBS="-lslurm "
 SLURM_LDFLAGS="-L${with_slurm_lib}"
-
 
 CPPFLAGS_save="$CPPFLAGS"
 LDFLAGS_save="$LDFLAGS"
 LIBS_save="$LIBS"
 LD_LIBRARY_PATH_save="$LD_LIBRARY_PATH"
 CPPFLAGS="$CPPFLAGS $SLURM_INCLUDES"
-LDFLAGS="$LDFLAGS $SLURM_LDFLAGS"
-LIBS="$LIBS $SLURM_LIBS"
 LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${with_slurm_lib}"
+LDFLAGS="$LDFLAGS $SLURM_LDFLAGS"
+
+SLURM_LIBS="-lslurm "
+dnl Check if slurmdb functions have been merged into the slurm library
+dnl If slurmdb has not been merged, add it to the working slurm libs
+AC_CHECK_LIB(slurm, slurmdb_users_get, [], [SLURM_LIBS="$SLURM_LIBS-lslurmdb "])
+AC_MSG_RESULT(Using slurm libraries $SLURM_LIBS)
+
+LIBS="$LIBS $SLURM_LIBS"
 
 ax_slurm_ok="no"
 


### PR DESCRIPTION
This PR removes the `libslurmdb` library only in newer versions of SLURM as it was merged in with `libslurm` on versions of SLURM past 18.

The details of this change can be found under the "28 May 2019" section of the `RELEASE_NOTES` and can be found on [the website](https://slurm.schedmd.com/news.html).

Additionally, this also fixes a configure option when using `--with-slurm-lib` to point at a custom directory for SLURM libraries. Since this directory also contains the runtime libraries, the test in `configure` now includes that directory for runtime linking when testing the SLURM test program after compilation.

Fixes Issue #28