### PR TITLE
Update Travis CI to include ClusterName in slurm.conf

### DIFF
--- a/.ci/slurm.conf
+++ b/.ci/slurm.conf
@@ -1,3 +1,4 @@
+ClusterName=test
 ControlMachine=localhost
 ControlAddr=127.0.0.1
 SlurmUser=slurm


### PR DESCRIPTION
Fixes a small issue in the Travis CI where operations fail because of no `ClusterName` found from `slurm.conf`