### PR TITLE
Try to retrieve job status from accounting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ HEAD (unreleased)
 ### New Features and Enhancements
 
 - Make compatible with Slurm 20.11 (@holtgrewe).
-- Retrieve job status from accounting (slurmdb) if already complete (instead of only looking at slurmd) (@holtgrewe)
+- Retrieve job status from accounting (slurmdb) if already complete (instead of only looking at slurmd) when `SLURM_DRMAA_USE_SLURMDBD` is set. (@holtgrewe)
 
 1.1.2 (2021-01-27)
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ HEAD (unreleased)
 
 ### New Features and Enhancements
 
+- Make compatible with Slurm 20.11 (@holtgrewe).
 - Retrieve job status from accounting (slurmdb) if already complete (instead of only looking at slurmd) (@holtgrewe)
 
 1.1.2 (2021-01-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+HEAD (unreleased)
+-----------------
+
+### New Features and Enhancements
+
+- Retrieve job status from accounting (slurmdb) if already complete (instead of only looking at slurmd) (@holtgrewe)
+
 1.1.2 (2021-01-27)
 ------------------
 

--- a/slurm_drmaa/drmaa.c
+++ b/slurm_drmaa/drmaa.c
@@ -217,3 +217,8 @@ fsd_drmaa_singletone_t _fsd_drmaa_singletone = {
 	slurmdrmaa_wcoredump,
 	slurmdrmaa_wifaborted
 };
+
+extern bool running_in_slurmctld(void)
+{
+    return false;
+}

--- a/slurm_drmaa/job.c
+++ b/slurm_drmaa/job.c
@@ -463,11 +463,11 @@ slurmdrmaa_job_on_missing( fsd_job_t *self )
 		job_cond->db_flags = SLURMDB_JOB_FLAG_NOTSET;
 #endif
 		job_cond->flags |= JOBCOND_FLAG_NO_TRUNC;
-		job_cond->step_list = slurm_list_create(slurmdb_destroy_selected_step);
+		job_cond->step_list = slurm_list_create(slurm_destroy_selected_step);
 
 		slurm_addto_step_list(job_cond->step_list, self->job_id);
 		job_cond->usage_end = time(NULL);
-        acct_db_conn = slurmdb_connection_get();
+		acct_db_conn = slurmdb_connection_get(NULL);
 		jobs = slurmdb_jobs_get(acct_db_conn, job_cond);
 		slurmdb_connection_close(&acct_db_conn);
 		slurm_list_destroy(job_cond->step_list);

--- a/slurm_drmaa/job.c
+++ b/slurm_drmaa/job.c
@@ -459,7 +459,9 @@ slurmdrmaa_job_on_missing( fsd_job_t *self )
 		fsd_log_info(( "Job %s has status %d, looking into accounting infos", self->job_id, self->state ));
 
 		job_cond = calloc(1, sizeof(slurmdb_job_cond_t));
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(19,5,0)
 		job_cond->db_flags = SLURMDB_JOB_FLAG_NOTSET;
+#endif
 		job_cond->flags |= JOBCOND_FLAG_NO_TRUNC;
 		job_cond->step_list = slurm_list_create(slurmdb_destroy_selected_step);
 

--- a/slurm_drmaa/job.c
+++ b/slurm_drmaa/job.c
@@ -456,43 +456,45 @@ slurmdrmaa_job_on_missing( fsd_job_t *self )
 		self->state = DRMAA_PS_FAILED;  /* assume failed if no job was found */
 		self->exit_status = -1;
 
-		fsd_log_info(( "Job %s has status %d, looking into accounting infos", self->job_id, self->state ));
+		if( getenv("SLURM_DRMAA_USE_SLURMDBD") ) { /* lookup job via slurmdbd if defined */
+			fsd_log_info(( "Job %s has status %d, looking into accounting infos", self->job_id, self->state ));
 
-		job_cond = calloc(1, sizeof(slurmdb_job_cond_t));
+			job_cond = calloc(1, sizeof(slurmdb_job_cond_t));
 #if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(19,5,0)
-		job_cond->db_flags = SLURMDB_JOB_FLAG_NOTSET;
+			job_cond->db_flags = SLURMDB_JOB_FLAG_NOTSET;
 #endif
-		job_cond->flags |= JOBCOND_FLAG_NO_TRUNC;
-		job_cond->step_list = slurm_list_create(slurm_destroy_selected_step);
+			job_cond->flags |= JOBCOND_FLAG_NO_TRUNC;
+			job_cond->step_list = slurm_list_create(slurm_destroy_selected_step);
 
-		slurm_addto_step_list(job_cond->step_list, self->job_id);
-		job_cond->usage_end = time(NULL);
-		acct_db_conn = slurmdb_connection_get(NULL);
-		jobs = slurmdb_jobs_get(acct_db_conn, job_cond);
-		slurmdb_connection_close(&acct_db_conn);
-		slurm_list_destroy(job_cond->step_list);
-		free(job_cond);
+			slurm_addto_step_list(job_cond->step_list, self->job_id);
+			job_cond->usage_end = time(NULL);
+			acct_db_conn = slurmdb_connection_get(NULL);
+			jobs = slurmdb_jobs_get(acct_db_conn, job_cond);
+			slurmdb_connection_close(&acct_db_conn);
+			slurm_list_destroy(job_cond->step_list);
+			free(job_cond);
 
-		if (jobs) {
-			itr = slurm_list_iterator_create(jobs);
+			if (jobs) {
+				itr = slurm_list_iterator_create(jobs);
 
-			job = slurm_list_next(itr);
-			if (!job) {
-				fsd_log_info(( "Job not found in accounting." ));
-			} else {
-				do {
-					fsd_log_info(( "Job found in accounting with exit code %d", job->exitcode ));
-					self->exit_status = job->exitcode;
-					if (self->exit_status == 0)
-						self->state = DRMAA_PS_DONE;
-					else
-						self->state = DRMAA_PS_FAILED;
+				job = slurm_list_next(itr);
+				if (!job) {
+					fsd_log_info(( "Job not found in accounting." ));
+				} else {
+					do {
+						fsd_log_info(( "Job found in accounting with exit code %d", job->exitcode ));
+						self->exit_status = job->exitcode;
+						if (self->exit_status == 0)
+							self->state = DRMAA_PS_DONE;
+						else
+							self->state = DRMAA_PS_FAILED;
 
-					break;
-				} while ((job = slurm_list_next(itr)));
+						break;
+					} while ((job = slurm_list_next(itr)));
+				}
+
+				slurm_list_iterator_destroy(itr);
 			}
-
-			slurm_list_iterator_destroy(itr);
 		}
 	}
 

--- a/slurm_drmaa/slurm_missing.h
+++ b/slurm_drmaa/slurm_missing.h
@@ -27,6 +27,8 @@
 extern void * slurm_list_peek (List l);
 extern void * slurm_list_remove (ListIterator i);
 
+extern int slurm_addto_step_list(List step_list, char *names);
+
 /* --clusters is not supported with Slurm < 15.08, but these are defined to
  * avoid compiler warnings
  */


### PR DESCRIPTION
At least in the case where Slurm accounting information is stored in a MySQL database, jobs that are completed are not available via the `slurm.h` functionality. Instead, the exit code has to be retrieved using the `slurmdb.h` functionality.

This patch extends the "`assume failed if no job was found`" in `slurmdrmaa_job_on_missing()` to look into `slurmdb` instead.