### PR TITLE
prototype of 'slurm_kill_job2' was changed for Slurm 21.08.0

### DIFF
--- a/slurm_drmaa/job.c
+++ b/slurm_drmaa/job.c
@@ -113,7 +113,9 @@ slurmdrmaa_job_control( fsd_job_t *self, int action )
 				}
 				break;
 			case DRMAA_CONTROL_TERMINATE:
-#if SLURM_VERSION_NUMBER > SLURM_VERSION_NUM(14,10,0)
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(21,8,0)
+				if(slurm_kill_job2(self->job_id, SIGKILL, 0, NULL) == -1) {
+#elif SLURM_VERSION_NUMBER > SLURM_VERSION_NUM(14,10,0)
 				if(slurm_kill_job2(self->job_id, SIGKILL, 0) == -1) {
 #else
 				if(slurm_kill_job(fsd_atoi(self->job_id), SIGKILL, 0) == -1) {


### PR DESCRIPTION
Hi Natefoo,

A simple pull request - the prototype of "slurm_kill_job2" was altered with the latest release of Slurm.

   -Greg