### PR TITLE
Conditional new sacct feature for older versions of Slurm, use fsd_* memory functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ HEAD (unreleased)
 
 ### New Features and Enhancements
 
-- Make compatible with Slurm 20.11 (@holtgrewe).
-- Retrieve job status from accounting (slurmdb) if already complete (instead of only looking at slurmd) when `SLURM_DRMAA_USE_SLURMDBD` is set. (@holtgrewe)
+- Retrieve job status from accounting (slurmdb) if already complete (instead of only looking at slurmd) when `SLURM_DRMAA_USE_SLURMDBD` is set. ([PR #39][pr39]; thanks @holtgrewe)
+
+[pr39]: https://github.com/natefoo/slurm-drmaa/pull/39
 
 1.1.2 (2021-01-27)
 ------------------

--- a/slurm_drmaa/job.c
+++ b/slurm_drmaa/job.c
@@ -463,7 +463,7 @@ slurmdrmaa_job_on_missing( fsd_job_t *self )
 			job_cond->db_flags = SLURMDB_JOB_FLAG_NOTSET;
 #endif
 			job_cond->flags |= JOBCOND_FLAG_NO_TRUNC;
-#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(19,5,0)
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(20,11,0)
 			job_cond->step_list = slurm_list_create(slurm_destroy_selected_step);
 #else
 			job_cond->step_list = slurm_list_create(slurmdb_destroy_selected_step);


### PR DESCRIPTION
Followup to #39, should fix tests.