### PR TITLE
Slurm 23.X.X requires "slurm_init()" to be called . .

### DIFF
--- a/slurm_drmaa/drmaa.c
+++ b/slurm_drmaa/drmaa.c
@@ -30,18 +30,27 @@
 
 #include <slurm_drmaa/session.h>
 #include <slurm/slurm.h>
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(23,0,0)
+#include <slurm_drmaa/util.h>
+#endif
 
 static char slurmdrmaa_version[50] = "";
 
 static fsd_drmaa_session_t *
 slurmdrmaa_new_session( fsd_drmaa_singletone_t *self, const char *contact )
 {
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(23,0,0)
+	slurmdrmaa_init();
+#endif
 	return slurmdrmaa_session_new( contact );
 }
 
 static fsd_template_t *
 slurmdrmaa_new_job_template( fsd_drmaa_singletone_t *self )
 {
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(23,0,0)
+	slurmdrmaa_init();
+#endif
 	return drmaa_template_new();
 }
 
@@ -61,6 +70,9 @@ slurmdrmaa_get_version( fsd_drmaa_singletone_t *self,
 static const char *
 slurmdrmaa_get_DRM_system( fsd_drmaa_singletone_t *self )
 {
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(23,0,0)
+	slurmdrmaa_init();
+#endif
 	if(slurmdrmaa_version[0] == '\0') /*no locks as drmaa_get_drm_system is usually called only once */
 	{
 #if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(20,11,0)

--- a/slurm_drmaa/util.c
+++ b/slurm_drmaa/util.c
@@ -728,10 +728,10 @@ slurmdrmaa_set_cluster(const char * value)
 static int slurmdrmaa_has_inited = 0;
 
 void
-slurmdrmaa_init( void )
+slurmdrmaa_init(void)
 {
-	if ( slurmdrmaa_has_inited != 1 ) {
-		slurm_init( NULL );
+	if (slurmdrmaa_has_inited != 1) {
+		slurm_init(NULL);
 		slurmdrmaa_has_inited = 1;
 	}
 }

--- a/slurm_drmaa/util.c
+++ b/slurm_drmaa/util.c
@@ -723,3 +723,16 @@ slurmdrmaa_set_cluster(const char * value)
 
 	fsd_log_return(( "" ));
 }
+
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(23,0,0)
+static int slurmdrmaa_has_inited = 0;
+
+void
+slurmdrmaa_init( void )
+{
+	if ( slurmdrmaa_has_inited != 1 ) {
+		slurm_init( NULL );
+		slurmdrmaa_has_inited = 1;
+	}
+}
+#endif

--- a/slurm_drmaa/util.h
+++ b/slurm_drmaa/util.h
@@ -37,5 +37,8 @@ void slurmdrmaa_parse_native(job_desc_msg_t *job_desc, const char * value);
 char * slurmdrmaa_set_job_id(job_id_spec_t *job_id_spec);
 char * slurmdrmaa_unset_job_id(job_id_spec_t *job_id_spec);
 void slurmdrmaa_set_cluster(const char * value);
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(23,0,0)
+void slurmdrmaa__init( void );
+#endif
 
 #endif /* __SLURM_DRMAA__UTIL_H */

--- a/slurm_drmaa/util.h
+++ b/slurm_drmaa/util.h
@@ -38,7 +38,7 @@ char * slurmdrmaa_set_job_id(job_id_spec_t *job_id_spec);
 char * slurmdrmaa_unset_job_id(job_id_spec_t *job_id_spec);
 void slurmdrmaa_set_cluster(const char * value);
 #if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(23,0,0)
-void slurmdrmaa__init( void );
+void slurmdrmaa__init(void);
 #endif
 
 #endif /* __SLURM_DRMAA__UTIL_H */


### PR DESCRIPTION
. . before using any commands from the Slurm API. Without this slurm_drmaa is causing segfaults inside libslurm.