### PR TITLE
List type was renamed in 24.05.X, and other minor patches.

### DIFF
--- a/.github/workflows/slurm-drmaa.yaml
+++ b/.github/workflows/slurm-drmaa.yaml
@@ -25,6 +25,9 @@ jobs:
           docker_image: rockylinux:8
           slurm_version: 23.11
         - os: ubuntu-latest
+          docker_image: rockylinux:8
+          slurm_version: 24.05
+        - os: ubuntu-latest
           docker_image: debian:bookworm
           slurm_version: 22.05
     env:

--- a/slurm_drmaa/job.c
+++ b/slurm_drmaa/job.c
@@ -379,22 +379,22 @@ slurmdrmaa_job_update_status( fsd_job_t *self )
 					fsd_log_debug(("interpreting as DRMAA_PS_FAILED (aborted)"));
 					self->state = DRMAA_PS_FAILED;
 					self->exit_status = -1;
-                    // fall through
+					// fall through
 				case JOB_FAILED:
-                    // fall through
+					// fall through
 				case JOB_TIMEOUT:
-                    // fall through
+					// fall through
 				case JOB_NODE_FAIL:
-                    // fall through
+					// fall through
 				case JOB_PREEMPTED:
-                    // fall through
+					// fall through
 #if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(14,3,0)
 				case JOB_BOOT_FAIL:
-                    // fall through
+					// fall through
 #endif
 #if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(16,5,0)
 				case JOB_DEADLINE:
-                    // fall through
+					// fall through
 #endif
 #if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(17,2,0)
 				case JOB_OOM:
@@ -1007,7 +1007,7 @@ _slurmdrmaa_set_prio_process_env(char **envp, unsigned int envpos)
 	if ((retval = getpriority(PRIO_PROCESS, 0)) == -1)  {
 		if (errno) {
 			fsd_log_error(("unable to set SLURM_PRIO_PROCESS in job environment: getpriority(PRIO_PROCESS): %s",
-                        strerror( errno ) ));
+				strerror( errno ) ));
 			return envpos;
 		}
 	}
@@ -1027,13 +1027,13 @@ _slurmdrmaa_set_submit_dir_env(char **envp, unsigned int envpos)
 
 	if ((getcwd(buf, MAXPATHLEN)) == NULL)
 		fsd_log_error(("unable to set SLURM_SUBMIT_DIR in job environment: getcwd failed: %s",
-                    strerror( errno ) ));
+			strerror( errno ) ));
 	else
 		envpos = _slurmdrmaa_add_envvar(envp, envpos, "SLURM_SUBMIT_DIR", buf);
 
 	if ((gethostname(host, sizeof(host))))
 		fsd_log_error(("unable to set SLURM_SUBMIT_HOST in environment: gethostname_short failed: %s",
-                    strerror( errno ) ));
+			strerror( errno ) ));
 	else
 		envpos = _slurmdrmaa_add_envvar(envp, envpos, "SLURM_SUBMIT_HOST", host);
 

--- a/slurm_drmaa/job.c
+++ b/slurm_drmaa/job.c
@@ -379,15 +379,22 @@ slurmdrmaa_job_update_status( fsd_job_t *self )
 					fsd_log_debug(("interpreting as DRMAA_PS_FAILED (aborted)"));
 					self->state = DRMAA_PS_FAILED;
 					self->exit_status = -1;
+                    // fall through
 				case JOB_FAILED:
+                    // fall through
 				case JOB_TIMEOUT:
+                    // fall through
 				case JOB_NODE_FAIL:
+                    // fall through
 				case JOB_PREEMPTED:
+                    // fall through
 #if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(14,3,0)
 				case JOB_BOOT_FAIL:
+                    // fall through
 #endif
 #if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(16,5,0)
 				case JOB_DEADLINE:
+                    // fall through
 #endif
 #if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(17,2,0)
 				case JOB_OOM:
@@ -438,7 +445,12 @@ slurmdrmaa_job_on_missing( fsd_job_t *self )
 	slurmdb_job_cond_t *job_cond = NULL;
 	slurmdb_job_rec_t *job = NULL;
 	List jobs;
+
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(24,5,0)
+	list_itr_t *itr = NULL;
+#else
 	ListIterator itr = NULL;
+#endif
 	void *acct_db_conn = NULL;
 
 	fsd_log_enter(( "({job_id=%s})", self->job_id ));
@@ -994,7 +1006,8 @@ _slurmdrmaa_set_prio_process_env(char **envp, unsigned int envpos)
 
 	if ((retval = getpriority(PRIO_PROCESS, 0)) == -1)  {
 		if (errno) {
-			fsd_log_error(("unable to set SLURM_PRIO_PROCESS in job environment: getpriority(PRIO_PROCESS): %m"));
+			fsd_log_error(("unable to set SLURM_PRIO_PROCESS in job environment: getpriority(PRIO_PROCESS): %s",
+                        strerror( errno ) ));
 			return envpos;
 		}
 	}
@@ -1013,12 +1026,14 @@ _slurmdrmaa_set_submit_dir_env(char **envp, unsigned int envpos)
 	char buf[MAXPATHLEN + 1], host[256];
 
 	if ((getcwd(buf, MAXPATHLEN)) == NULL)
-		fsd_log_error(("unable to set SLURM_SUBMIT_DIR in job environment: getcwd failed: %m"));
+		fsd_log_error(("unable to set SLURM_SUBMIT_DIR in job environment: getcwd failed: %s",
+                    strerror( errno ) ));
 	else
 		envpos = _slurmdrmaa_add_envvar(envp, envpos, "SLURM_SUBMIT_DIR", buf);
 
 	if ((gethostname(host, sizeof(host))))
-		fsd_log_error(("unable to set SLURM_SUBMIT_HOST in environment: gethostname_short failed: %m"));
+		fsd_log_error(("unable to set SLURM_SUBMIT_HOST in environment: gethostname_short failed: %s",
+                    strerror( errno ) ));
 	else
 		envpos = _slurmdrmaa_add_envvar(envp, envpos, "SLURM_SUBMIT_HOST", host);
 

--- a/slurm_drmaa/slurm_missing.h
+++ b/slurm_drmaa/slurm_missing.h
@@ -25,7 +25,9 @@
 #define __LL_DRMAA__SLURM_MISSING_H
 
 extern void * slurm_list_peek (List l);
+#if SLURM_VERSION_NUMBER < SLURM_VERSION_NUM(24,5,0)
 extern void * slurm_list_remove (ListIterator i);
+#endif
 
 extern int slurm_addto_step_list(List step_list, char *names);
 


### PR DESCRIPTION
In 24.05 ListIterator was renamed to list_itr_t

slurm_list_remove was defined as an extern but wasn't used so remove using conditional for 24.05

added // fall through to suppress gcc compiler warnings

fixed fsd_log_error which also caused compiler issues.