### PR TITLE
Changes to build against Slurm 24.11

### DIFF
--- a/slurm_drmaa/slurm_missing.h
+++ b/slurm_drmaa/slurm_missing.h
@@ -24,12 +24,16 @@
 #ifndef __LL_DRMAA__SLURM_MISSING_H
 #define __LL_DRMAA__SLURM_MISSING_H
 
+#if SLURM_VERSION_NUMBER < SLURM_VERSION_NUM(24,11,0)
 extern void * slurm_list_peek (List l);
+#endif
 #if SLURM_VERSION_NUMBER < SLURM_VERSION_NUM(24,5,0)
 extern void * slurm_list_remove (ListIterator i);
 #endif
 
+#if SLURM_VERSION_NUMBER < SLURM_VERSION_NUM(24,11,0)
 extern int slurm_addto_step_list(List step_list, char *names);
+#endif
 
 /* --clusters is not supported with Slurm < 15.08, but these are defined to
  * avoid compiler warnings

--- a/slurm_drmaa/util.c
+++ b/slurm_drmaa/util.c
@@ -28,6 +28,8 @@
 #include <slurm_drmaa/slurm_missing.h>
 #include <slurm_drmaa/slurm_drmaa.h>
 
+#include <slurm/slurm_version.h>
+
 unsigned int
 slurmdrmaa_datetime_parse( const char *string )
 {
@@ -690,7 +692,11 @@ slurmdrmaa_unset_job_id(job_id_spec_t *job_id_spec)
 void
 slurmdrmaa_set_cluster(const char * value)
 {
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(24,11,0)
+    list_t *cluster_list = NULL;
+#else
 	volatile List cluster_list = NULL;
+#endif
 
 	fsd_log_enter(( "({value=%s})", value));
 


### PR DESCRIPTION

The slurm APIs return an error code, with slurm_get_errno() being removed.

This AP style is present in 24.05.X however slurm_get_errno() still exists - I've made no attempt to cleanup the 24.05.