### PR TITLE
Compatibility changes for Slurm 24.11

### DIFF
--- a/slurm_drmaa/drmaa.c
+++ b/slurm_drmaa/drmaa.c
@@ -76,13 +76,20 @@ slurmdrmaa_get_DRM_system( fsd_drmaa_singletone_t *self )
 	if(slurmdrmaa_version[0] == '\0') /*no locks as drmaa_get_drm_system is usually called only once */
 	{
 #if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(20,11,0)
-		slurm_conf_t * conf_info_msg_ptr = NULL; 
+		slurm_conf_t * conf_info_msg_ptr = NULL;
 #else
-		slurm_ctl_conf_t * conf_info_msg_ptr = NULL; 
+		slurm_ctl_conf_t * conf_info_msg_ptr = NULL;
 #endif
-		if ( slurm_load_ctl_conf ((time_t) NULL, &conf_info_msg_ptr ) == -1 ) 
-		{ 
-			fsd_log_error(("slurm_load_ctl_conf error: %s",slurm_strerror(slurm_get_errno())));
+		int _serrno;
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(24,11,0)
+		if ( (_serrno = slurm_load_ctl_conf ((time_t) NULL, &conf_info_msg_ptr )) != SLURM_SUCCESS )
+		{
+#else
+		if ( slurm_load_ctl_conf ((time_t) NULL, &conf_info_msg_ptr ) == -1 )
+		{
+			_serrno = slurm_get_errno();
+#endif
+			fsd_log_error(("slurm_load_ctl_conf error: %s",slurm_strerror(_serrno)));
 			fsd_snprintf(NULL, slurmdrmaa_version, sizeof(slurmdrmaa_version)-1,"SLURM");
 		}
 		else
@@ -192,7 +199,7 @@ slurmdrmaa_wcoredump(
 		)
 {
 	/**core_dumped = 0;*/
-	*core_dumped = ((stat)&0200); 
+	*core_dumped = ((stat)&0200);
 	return DRMAA_ERRNO_SUCCESS;
 }
 

--- a/slurm_drmaa/slurm_missing.h
+++ b/slurm_drmaa/slurm_missing.h
@@ -24,12 +24,16 @@
 #ifndef __LL_DRMAA__SLURM_MISSING_H
 #define __LL_DRMAA__SLURM_MISSING_H
 
+#if SLURM_VERSION_NUMBER < SLURM_VERSION_NUM(24,11,0)
 extern void * slurm_list_peek (List l);
+#endif
 #if SLURM_VERSION_NUMBER < SLURM_VERSION_NUM(24,5,0)
 extern void * slurm_list_remove (ListIterator i);
 #endif
 
+#if SLURM_VERSION_NUMBER < SLURM_VERSION_NUM(24,11,0)
 extern int slurm_addto_step_list(List step_list, char *names);
+#endif
 
 /* --clusters is not supported with Slurm < 15.08, but these are defined to
  * avoid compiler warnings

--- a/slurm_drmaa/util.c
+++ b/slurm_drmaa/util.c
@@ -690,7 +690,11 @@ slurmdrmaa_unset_job_id(job_id_spec_t *job_id_spec)
 void
 slurmdrmaa_set_cluster(const char * value)
 {
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(24,11,0)
+    list_t *cluster_list = NULL;
+#else
 	volatile List cluster_list = NULL;
+#endif
 
 	fsd_log_enter(( "({value=%s})", value));
 


### PR DESCRIPTION
In 24.11 slurm_get_errno() was removed as the errcode of the API call is being the return value (with SLURM_SUCCESS == no error).

This is also present in in 24.05.X however slurm_get_errno() still exists.