### PR TITLE
Fixes for Slurm 25.11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT([DRMAA for Slurm],[m4_esyscmd_s(./m4/ac_version.sh)],[nate@bx.psu.edu],[slurm-drmaa])
-AC_PREREQ([2.72])
+AC_PREREQ([2.71])
 AC_REVISION([m4_esyscmd_s([git rev-parse HEAD])])
 AC_COPYRIGHT([
 DRMAA for Slurm
@@ -50,7 +50,6 @@ AC_PROG_MAKE_SET
 AC_PROG_LN_S
 
 # check compiler / set basic flags:
-
 if test x$GCC = xyes; then
 	CFLAGS="-pedantic -std=c99 ${CFLAGS}"
 fi

--- a/slurm_drmaa/job.c
+++ b/slurm_drmaa/job.c
@@ -92,7 +92,11 @@ slurmdrmaa_job_control( fsd_job_t *self, int action )
 				/* change priority to 0*/
 				slurm_init_job_desc_msg(&job_desc);
 				slurm_self->old_priority = job_desc.priority;
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(25,11,0)
+				job_desc.job_id_str = self->job_id;
+#else
 				job_desc.job_id = atoi(self->job_id);
+#endif
 				job_desc.priority = 0;
 				job_desc.alloc_sid = 0;
 #if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(24,11,0)
@@ -122,7 +126,11 @@ slurmdrmaa_job_control( fsd_job_t *self, int action )
 			  /* change priority back*/
 			  	slurm_init_job_desc_msg(&job_desc);
 				job_desc.priority = INFINITE;
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(25,11,0)
+				job_desc.job_id_str = self->job_id;
+#else
 				job_desc.job_id = atoi(self->job_id);
+#endif
 #if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(24,11,0)
 				if((_serrno = slurm_update_job(&job_desc)) != SLURM_SUCCESS ) {
 #else

--- a/slurm_drmaa/slurm_missing.h
+++ b/slurm_drmaa/slurm_missing.h
@@ -25,14 +25,14 @@
 #define __LL_DRMAA__SLURM_MISSING_H
 
 #if SLURM_VERSION_NUMBER < SLURM_VERSION_NUM(24,11,0)
-extern void * slurm_list_peek (List l);
+extern void * slurm_list_peek(List l);
+extern int slurm_addto_step_list(List step_list, char *names);
+#else
+extern void * slurm_list_peek(list_t *l);
+extern int slurm_addto_step_list(list_t *step_list, char *names);
 #endif
 #if SLURM_VERSION_NUMBER < SLURM_VERSION_NUM(24,5,0)
-extern void * slurm_list_remove (ListIterator i);
-#endif
-
-#if SLURM_VERSION_NUMBER < SLURM_VERSION_NUM(24,11,0)
-extern int slurm_addto_step_list(List step_list, char *names);
+extern void * slurm_list_remove(ListIterator i);
 #endif
 
 /* --clusters is not supported with Slurm < 15.08, but these are defined to


### PR DESCRIPTION
Also undoes the version gating of `slurm_addto_step_list()` discussed in #95 and #96.